### PR TITLE
Fixed missing ':' in init.sls.

### DIFF
--- a/pam-ldap/init.sls
+++ b/pam-ldap/init.sls
@@ -8,7 +8,7 @@ tls_cacertfile:
     - mode: 640
 
 pam-ldap:
-  pkg.installed
+  pkg.installed:
     - name: {{ pam_ldap.pkg }}
 
 {{ pam_ldap.config }}:


### PR DESCRIPTION
This fixes a missing colon in the `pkg` definition that was removed in the previous commit.